### PR TITLE
Added CRLF to Cache-Control string

### DIFF
--- a/fs_handlers.c
+++ b/fs_handlers.c
@@ -33,6 +33,10 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#ifndef CRLF
+#define CRLF "\r\n"
+#endif
+
 #include "webui.h"
 
 #include "networking/httpd.h"
@@ -199,7 +203,7 @@ static bool _fs_ls (void *request, char *path, char *status, vfs_file_t *file, v
         if(json_end(root))
            data_is_json();
 
-        http_set_rom_response_header(request, "Cache-Control: no-cache");
+        http_set_rom_response_header(request, "Cache-Control: no-cache" CRLF);
     }
 
     return ok;

--- a/login.c
+++ b/login.c
@@ -32,6 +32,10 @@
 #include <string.h>
 #include <stdio.h>
 
+#ifndef CRLF
+#define CRLF "\r\n"
+#endif
+
 #include "grbl/vfs.h"
 #include "grbl/strutils.h"
 #include "grbl/nvs_buffer.h"
@@ -311,7 +315,7 @@ static const char *login (login_form_data_t *login)
         http_set_response_status(login->request, paranoia);
     }
 
-    http_set_rom_response_header(login->request, "Cache-Control: no-cache");
+    http_set_rom_response_header(login->request, "Cache-Control: no-cache" CRLF);
 
     webui_auth_level_t current_level = get_auth_level(login->request);
 

--- a/server.c
+++ b/server.c
@@ -30,6 +30,10 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#ifndef CRLF
+#define CRLF "\r\n"
+#endif
+
 #include "networking/websocketd.h"
 #include "networking/networking.h"
 #include "networking/utils.h"
@@ -233,7 +237,7 @@ static const char *command (http_request_t *request)
         http_get_param_value(request, "plain", data, sizeof(data));
 #endif
 
-    http_set_rom_response_header(request, "Cache-Control: no-cache");
+    http_set_rom_response_header(request, "Cache-Control: no-cache" CRLF);
 
     if(ping) {
 


### PR DESCRIPTION
Add proper CRLF handling for Cache-Control headers.
This fixes a malformed response where Cache-Control was concatenated with CORS headers, causing browsers to reject CORS.

Changes:
Append CRLF to "Cache-Control: no-cache" in fs_handlers.c, server.c, and login.c.
Define CRLF locally (guarded) in those files to keep header formatting consistent.

**Before change:**

❯ curl -i -H "Origin: http://localhost:3000" \
     "http://192.168.1.36/command?cmd=%24%24" 
HTTP/1.1 200 OK
Server: lwIP/2.2.0 (http://savannah.nongnu.org/projects/lwip)
Cache-Control: no-cacheAccess-Control-Allow-Origin: *.      **_<----- PROBLEM HERE_**
Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With
Access-Control-Max-Age: 86400
Access-Control-Allow-Methods: HEAD,GET,POST,OPTIONS
Content-Type: text/plain
Connection: keep-alive
Content-Length: 2

**After change:**

❯ curl -i -H "Origin: http://localhost:3000" \
     "http://192.168.1.36/command?cmd=%24%24"
HTTP/1.1 200 OK
Server: lwIP/2.2.0 (http://savannah.nongnu.org/projects/lwip)
Cache-Control: no-cache
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With
Access-Control-Max-Age: 86400
Access-Control-Allow-Methods: HEAD,GET,POST,OPTIONS
Content-Type: text/plain
Connection: keep-alive
Content-Length: 2

ok%    